### PR TITLE
User/wilson j99/images

### DIFF
--- a/backend/src/main/java/com/statit/backend/service/CategoryService.java
+++ b/backend/src/main/java/com/statit/backend/service/CategoryService.java
@@ -23,14 +23,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Base64;
 import java.util.UUID;
-import javax.imageio.ImageIO;
 
 //----------------------------------------------------------------------------------------------------
 // Class Definition
@@ -102,7 +97,7 @@ public class CategoryService
             throw new IllegalArgumentException("Category already exists.");
         }
 
-        String normalizedImageData = validateAndNormalizeImageData(imageData);
+        String normalizedImageData = normalizeImageData(imageData);
 
         //Create and save the category
         Category category = new Category(
@@ -157,7 +152,7 @@ public class CategoryService
 
         String normalizedImageData = imageData == null
                 ? category.getImageData()
-                : validateAndNormalizeImageData(imageData);
+                : normalizeImageData(imageData);
 
         category.update(name, description, units, tags, sortOrder, lowerLimit, upperLimit, normalizedImageData);
         return categoryRepository.save(category);
@@ -244,34 +239,12 @@ public class CategoryService
         globalBaselineRepository.save(baseline);
     }
 
-    private String validateAndNormalizeImageData(String imageData)
+    private String normalizeImageData(String imageData)
     {
         if(imageData == null) return null;
 
         String normalized = imageData.trim();
         if(normalized.isEmpty()) return null;
-
-        String base64 = normalized;
-        int commaIndex = base64.indexOf(',');
-        if(base64.toLowerCase().startsWith("data:image") && commaIndex >= 0)
-        {
-            base64 = base64.substring(commaIndex + 1);
-        }
-
-        try
-        {
-            byte[] imageBytes = Base64.getMimeDecoder().decode(base64);
-            BufferedImage image = ImageIO.read(new ByteArrayInputStream(imageBytes));
-
-            if(image == null || image.getWidth() != 512 || image.getHeight() != 512)
-            {
-                throw new IllegalArgumentException(CATEGORY_IMAGE_DIMENSIONS_ERROR);
-            }
-        }
-        catch(IllegalArgumentException | IOException e)
-        {
-            throw new IllegalArgumentException(CATEGORY_IMAGE_DIMENSIONS_ERROR);
-        }
 
         return normalized;
     }
@@ -282,5 +255,4 @@ public class CategoryService
     private final CategoryRepository categoryRepository;
     private final GlobalBaselineRepository globalBaselineRepository;
     private final ScoreRepository scoreRepository;
-    private static final String CATEGORY_IMAGE_DIMENSIONS_ERROR = "Image must be exactly 512x512 pixels.";
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -257,7 +257,7 @@ a { color: inherit; text-decoration: none; }
   background-position: center;
   background-size: contain;
   background-repeat: no-repeat;
-  filter: blur(14px);
+  filter: blur(8px);
   opacity: 0;
   transform: scale(1.08);
 }
@@ -316,6 +316,14 @@ a { color: inherit; text-decoration: none; }
   color: #fff;
 }
 
+.category-card.has-image h3,
+.category-card.has-image .card-meta,
+.category-card.has-image .tag {
+  text-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.85),
+    0 0 12px rgba(0, 0, 0, 0.55);
+}
+
 @media (max-width: 560px) {
   .card-grid {
     grid-template-columns: minmax(0, 1fr);
@@ -367,8 +375,8 @@ a { color: inherit; text-decoration: none; }
 }
 
 .category-title-icon {
-  width: 48px;
-  height: 48px;
+  width: 58px;
+  height: 58px;
   border: 1px solid var(--border);
   border-radius: 10px;
   object-fit: contain;

--- a/frontend/src/pages/AdminCategoryEditPage.jsx
+++ b/frontend/src/pages/AdminCategoryEditPage.jsx
@@ -6,6 +6,7 @@ import {
   adminApproveCategory,
   adminDeleteCategory,
 } from '../api';
+import { cropImageFileToSquare } from '../utils/imageCrop';
 
 const getCategoryImage = (category) => category?.imageData || category?.image_data || '';
 
@@ -75,16 +76,19 @@ export default function AdminCategoryEditPage({ currentUser }) {
     };
   };
 
-  const handleImageChange = (e) => {
+  const handleImageChange = async (e) => {
     const file = e.target.files?.[0];
     if (!file) {
       return;
     }
 
-    const reader = new FileReader();
-    reader.onload = () => setImageData(String(reader.result || ''));
-    reader.onerror = () => setError('Failed to read image.');
-    reader.readAsDataURL(file);
+    try {
+      setError('');
+      const croppedImage = await cropImageFileToSquare(file);
+      setImageData(croppedImage);
+    } catch (err) {
+      setError(err.message || 'Failed to process image.');
+    }
   };
 
   const handleSave = async () => {

--- a/frontend/src/pages/CreateCategoryPage.jsx
+++ b/frontend/src/pages/CreateCategoryPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createCategory } from '../api';
+import { cropImageFileToSquare } from '../utils/imageCrop';
 
 export default function CreateCategoryPage({ currentUser }) {
   const [name, setName] = useState('');
@@ -16,17 +17,21 @@ export default function CreateCategoryPage({ currentUser }) {
   const [upperLimit, setUpperLimit] = useState('');
   const [imageData, setImageData] = useState('');
 
-  const handleImageChange = (e) => {
+  const handleImageChange = async (e) => {
     const file = e.target.files?.[0];
     if (!file) {
       setImageData('');
       return;
     }
 
-    const reader = new FileReader();
-    reader.onload = () => setImageData(String(reader.result || ''));
-    reader.onerror = () => setError('Failed to read image.');
-    reader.readAsDataURL(file);
+    try {
+      setError('');
+      const croppedImage = await cropImageFileToSquare(file);
+      setImageData(croppedImage);
+    } catch (err) {
+      setImageData('');
+      setError(err.message || 'Failed to process image.');
+    }
   };
 
 const handleSubmit = async (e) => {

--- a/frontend/src/utils/imageCrop.js
+++ b/frontend/src/utils/imageCrop.js
@@ -1,0 +1,51 @@
+const DEFAULT_OUTPUT_SIZE = 512;
+
+export function cropImageFileToSquare(file, outputSize = DEFAULT_OUTPUT_SIZE) {
+  return new Promise((resolve, reject) => {
+    if (!file) {
+      resolve('');
+      return;
+    }
+
+    const image = new Image();
+    const objectUrl = URL.createObjectURL(file);
+
+    image.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+
+      const sourceSize = Math.min(image.naturalWidth, image.naturalHeight);
+      const sourceX = (image.naturalWidth - sourceSize) / 2;
+      const sourceY = (image.naturalHeight - sourceSize) / 2;
+      const canvas = document.createElement('canvas');
+      canvas.width = outputSize;
+      canvas.height = outputSize;
+
+      const context = canvas.getContext('2d');
+      if (!context) {
+        reject(new Error('Could not process image.'));
+        return;
+      }
+
+      context.drawImage(
+        image,
+        sourceX,
+        sourceY,
+        sourceSize,
+        sourceSize,
+        0,
+        0,
+        outputSize,
+        outputSize
+      );
+
+      resolve(canvas.toDataURL('image/png'));
+    };
+
+    image.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error('Failed to load image.'));
+    };
+
+    image.src = objectUrl;
+  });
+}


### PR DESCRIPTION
This PR adds support for category images and improves admin and category page UX bugs. Categories can now store image data through the backend API, and uploaded category images are checked to make sure they are 512x512 pixels.

The frontend now displays category images on the homepage and admin category cards, and shows the image as a small icon beside the category title on the category detail page. Admins can also view and update category images while reviewing or editing categories.

This PR also adds confirmation prompts for important admin actions, including approving categories, deleting categories or scores, and granting admin permissions. The backend median calculation now correctly handles categories with only one participant.